### PR TITLE
added combat level filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.25'
+def runeLiteVersion = '1.8.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/es/weedl/AccountChatFilterConfig.java
+++ b/src/main/java/es/weedl/AccountChatFilterConfig.java
@@ -129,4 +129,12 @@ public interface AccountChatFilterConfig extends Config
 			section = accountTypesSection
 	)
 	default boolean filterLeague() { return false; }
+
+	@ConfigItem(
+			keyName = "filteredCombatLevel",
+			name = "Combat Level",
+			description = "Filters chat based on combat level given",
+			position = 27
+	)
+	default int filteredCombatLevel() { return 1; }
 }

--- a/src/main/java/es/weedl/AccountChatFilterPlugin.java
+++ b/src/main/java/es/weedl/AccountChatFilterPlugin.java
@@ -266,6 +266,25 @@ public class AccountChatFilterPlugin extends Plugin
 			return true;
 		}
 
+		Player player = getPlayerFromName(name);
+		if (player != null && player.getCombatLevel() <= config.filteredCombatLevel()) {
+			return true;
+		}
+
 		return config.filterNormalAccounts() && isNormalAccount(name);
+	}
+
+	private Player getPlayerFromName(String playerName) {
+		String sanitizedName = Text.standardize(playerName);
+
+		Player player = null;
+		for (Player p : client.getPlayers()) {
+			if (p.getName().toLowerCase().equals(sanitizedName)) {
+				player = p;
+				break;
+			}
+		}
+
+		return player;
 	}
 }


### PR DESCRIPTION
This is related to https://github.com/runelite/runelite/issues/14350
I already had a [PR](https://github.com/runelite/plugin-hub/pull/2093) to the plugin-hub with my own [repo ](https://github.com/orange-puff/runelite-plugins-external/tree/7ac1421b6c92164b01b9046acee48bed6fdf5072)
and it was suggested that I move my changes into your plugin.

This adds a combat level filter to shut level 3 GE bots up