### PR TITLE
Add option to hide character models of filtered players

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.2'
+def runeLiteVersion = '1.10.12'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/es/weedl/AccountChatFilterConfig.java
+++ b/src/main/java/es/weedl/AccountChatFilterConfig.java
@@ -146,4 +146,12 @@ public interface AccountChatFilterConfig extends Config
 			position = 28
 	)
 	default int filteredCombatLevel() { return 1; }
+
+	@ConfigItem(
+			keyName = "hideCharacterModels",
+			name = "Hide Character Models",
+			description = "Hides the in-game character model of any filtered players",
+			position = 29
+	)
+	default boolean hideCharacterModels() { return false; }
 }


### PR DESCRIPTION
It's the equivalent of automatically applying Entity Hider to certain account types (after the first time they speak.) 